### PR TITLE
安装依赖库脚本优化

### DIFF
--- a/data/shell/install_deb.sh
+++ b/data/shell/install_deb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+sudo apt install omxplayer pulseaudio fswebcam
+sudo apt install cmake g++ gcc python2.7 python3
+sudo apt install python-dev python3-dev python-pyaudio python3-pyaudio sox
+pip install pyaudio sendmail
+pip install requests hyper crypto
+sudo apt-get install libatlas-base-dev
+mv /home/pi/xiaolan-dev /home/pi/xiaolan
+echo "请输入root账号的密码："
+echo "如果输入完毕之后，停止了运行，在本脚本文件里找到本行，往下数第二行一直拖到最底复制带命令行中执行"
+su
+cp ~/pi/xiaolan/xiaolan/autostartxl /etc/init.d/
+chmod +777 /etc/init.d/autostartxl
+sudo update-rc.d autostartxl defaults
+cd ~/pi/xiaolan/xiaolan
+python xldo.py b

--- a/data/shell/install_fc.sh
+++ b/data/shell/install_fc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+su
+dnf install git cmake g++ gcc python3-devel.x86_64 make ffmpeg pulseaudio.x86_64 fswebcam.x86_64 sox.x86_64
+git clone https://github.com/popcornmix/omxplayer.git
+./prepare-native-raspbian.sh
+pip install -i https://mirrors.ustc.edu.cn/pypi/web/simple pip -U
+pip config set global.index-url https://mirrors.ustc.edu.cn/pypi/web/simple
+pip install PyAudio sox
+pip install pyaudio sendmail
+pip install requests hyper crypto
+mv /home/pi/xiaolan-dev /home/pi/xiaolan
+echo "请输入root账号的密码："
+echo "如果输入完毕之后，停止了运行，在本脚本文件里找到本行，往下数第二行一直拖到最底复制带命令行中执行"
+su root
+cp /home/pi/xiaolan/xiaolan/autostartxl /etc/init.d/
+chmod +777 /etc/init.d/autostartxl
+sudo update-rc.d autostartxl defaults
+cd /home/pi/xiaolan/xiaolan
+python xldo.py b


### PR DESCRIPTION
原先的脚本改名为install_deb.sh。新增适用于fedora/redhat/centos/centos stream的安装依赖脚本。原先脚本还保留。只是为了方便RPM系的安装。暂未找到运行install_all.sh脚本的程序。希望蓝之酱大佬可以帮我找出来。过几天写个检测DEB还是RPM系的程序